### PR TITLE
Use encode/decodeURI to avoid issues with safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ Krumkake.prototype._read = function() {
   if (!this.data) {
     // get existing data
     var data = this.cookies.get(this.cookieName, this.getOpts)
-    this.data = data && JSON.parse(data) || {}
+    this.data = data && JSON.parse(decodeURIComponent(data)) || {}
     // write the cookie again to set the expires header
     this._write()
   }
@@ -87,5 +87,6 @@ Krumkake.prototype._read = function() {
 Krumkake.prototype._write = function() {
   var opts = this.setOpts
   opts.expires = new Date((+new Date) + (this.expire*1000))
-  this.cookies.set(this.cookieName, JSON.stringify(this.data), opts)
+  var data = this.data && encodeURIComponent(JSON.stringify(this.data))
+  this.cookies.set(this.cookieName, data, opts)
 }

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ Krumkake.prototype._read = function() {
 Krumkake.prototype._write = function() {
   var opts = this.setOpts
   opts.expires = new Date((+new Date) + (this.expire*1000))
-  var data = this.data && encodeURIComponent(JSON.stringify(this.data))
+  var data = JSON.stringify(this.data)
+  data = data && encodeURIComponent(data)
   this.cookies.set(this.cookieName, data, opts)
 }


### PR DESCRIPTION
Safari has issues with commas and whitespace in cookie data.  This PR leverages `encode/decodeURIComponent` to escape them.

https://developer.mozilla.org/en-US/docs/Web/API/document/cookie
> The cookie value string can use encodeURIComponent() to ensure that the string does not contain any commas, semicolons, or whitespace (which are disallowed in cookie values).

#### Notes
If this ever needs to be rolled back, we should retain the `decodeURIComponent` otherwise `JSON.parse()` will barf when it encounters the first `%`.