### PR TITLE
Update some tests for encodeURI (and dellAll())

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -212,7 +212,7 @@ describe('Session', function() {
       val = krumkake.get('two')
       assert(!val)
 
-      assert(cookies.set.calledWithExactly('s'))
+      assert(cookies.set.calledWithExactly('s', '', krumkake.setOpts))
 
       done()
     })

--- a/test/test.js
+++ b/test/test.js
@@ -73,7 +73,7 @@ describe('Session', function() {
       krumkake.set('foo', 'bar')
       assert.equal(krumkake.data['foo'], 'bar')
       // console.log(cookies.set.getCall(0).args)
-      assert(cookies.set.calledWith('s', '{"foo":"bar"}'))
+      assert(cookies.set.calledWith('s', encodeURIComponent('{"foo":"bar"}')))
       done()
     })
 
@@ -81,7 +81,7 @@ describe('Session', function() {
       krumkake.set({'foo':'bar', 'baz':'foo'})
       assert.equal(krumkake.data['foo'], 'bar')
       assert.equal(krumkake.data['baz'], 'foo')
-      assert(cookies.set.calledWith('s', '{"foo":"bar","baz":"foo"}'))
+      assert(cookies.set.calledWith('s', encodeURIComponent('{"foo":"bar","baz":"foo"}')))
       done()
     })
 
@@ -90,7 +90,7 @@ describe('Session', function() {
       var val = { bar:'baz' }
       krumkake.set(key, val)
       assert.strictEqual(krumkake.data[key], val)
-      assert(cookies.set.calledWith('s', '{"foo":{"bar":"baz"}}'))
+      assert(cookies.set.calledWith('s', encodeURIComponent('{"foo":{"bar":"baz"}}')))
       done()
     })
 


### PR DESCRIPTION
Update some tests:
- Use `encodeURIComponent` when testing `cookie.set()` calls.
- Update `dellAll()` test for [0.2.1 code change](https://github.com/mikefrey/krumkake/commit/485496d39e88c45f6424ca50fb87da02fc6a6ca4)
